### PR TITLE
Add compile-time option to disable stdio FILE usage

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -501,6 +501,7 @@ LJCORE_O= lj_assert.o lj_gc.o lj_err.o lj_char.o lj_bc.o lj_obj.o lj_buf.o \
 	  lj_ctype.o lj_cdata.o lj_cconv.o lj_ccall.o lj_ccallback.o \
 	  lj_carith.o lj_clib.o lj_cparse.o \
 	  lj_lib.o lj_alloc.o lib_aux.o \
+	  lj_stdio.o \
 	  $(LJLIB_O) lib_init.o
 
 LJVMCORE_O= $(LJVM_O) $(LJCORE_O)

--- a/src/Makefile.dep
+++ b/src/Makefile.dep
@@ -218,6 +218,7 @@ lj_vmevent.o: lj_vmevent.c lj_obj.h lua.h luaconf.h lj_def.h lj_arch.h \
  lj_vm.h lj_vmevent.h
 lj_vmmath.o: lj_vmmath.c lj_obj.h lua.h luaconf.h lj_def.h lj_arch.h \
  lj_ir.h lj_vm.h
+lj_stdio.o: lj_stdio.c lua.h lj_def.h lj_arch.h
 ljamalg.o: ljamalg.c lua.h luaconf.h lauxlib.h lj_assert.c lj_obj.h \
  lj_def.h lj_arch.h lj_gc.c lj_gc.h lj_err.h lj_errmsg.h lj_buf.h \
  lj_str.h lj_tab.h lj_func.h lj_udata.h lj_meta.h lj_state.h lj_frame.h \

--- a/src/lib_base.c
+++ b/src/lib_base.c
@@ -516,6 +516,8 @@ LJLIB_CF(newproxy)
 LJLIB_PUSH("tostring")
 LJLIB_CF(print)
 {
+  lua_Print print = G(L)->printf;
+  void *printd = G(L)->printd;
   ptrdiff_t i, nargs = L->top - L->base;
   cTValue *tv = lj_tab_getstr(tabref(L->env), strV(lj_lib_upvalue(L, 1)));
   int shortcut;
@@ -546,10 +548,10 @@ LJLIB_CF(print)
       L->top--;
     }
     if (i)
-      putchar('\t');
-    fwrite(str, 1, size, stdout);
+      print(L, "\t", 1, printd);
+    print(L, str, size, printd);
   }
-  putchar('\n');
+  print(L, "\n", 1, printd);
   return 0;
 }
 

--- a/src/lib_jit.c
+++ b/src/lib_jit.c
@@ -759,3 +759,20 @@ LUALIB_API int luaopen_jit(lua_State *L)
   return 1;
 }
 
+LUA_API lua_State *luaJIT_newstate(lua_Alloc alloc_f, void *alloc_ud,
+				   lua_Panic panic_f, void *panic_ud,
+				   lua_Print print_f, void *print_ud)
+{
+  lua_State *L = lua_newstate(alloc_f, alloc_ud);
+  if (L) {
+      if (panic_f) {
+	G(L)->panicf = panic_f;
+	G(L)->panicd = panic_ud;
+      }
+      if (print_f) {
+	G(L)->printf = print_f;
+	G(L)->printd = print_ud;
+      }
+  }
+  return L;
+}

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -10,6 +10,7 @@
 #define _LJ_OBJ_H
 
 #include "lua.h"
+#include "luajit.h"
 #include "lj_def.h"
 #include "lj_arch.h"
 
@@ -631,6 +632,10 @@ typedef struct StrInternState {
 typedef struct global_State {
   lua_Alloc allocf;	/* Memory allocator. */
   void *allocd;		/* Memory allocator data. */
+  lua_Panic panicf;	/* Panic handler. */
+  void *panicd;		/* Panic handler data. */
+  lua_Print printf;	/* Print to stdout. */
+  void *printd;		/* Print to stdout data. */
   GCState gc;		/* Garbage collector. */
   GCstr strempty;	/* Empty string. */
   uint8_t stremptyz;	/* Zero terminator of empty string. */

--- a/src/lj_stdio.c
+++ b/src/lj_stdio.c
@@ -1,0 +1,81 @@
+/*
+** Stubs for code that references stdio in libc
+** Copyright (C) 2023 Crash Override, Inc.
+*/
+
+#define lj_stdio_c
+#define LUA_CORE
+
+#include "lua.h"
+#include "lj_def.h"
+#include "lj_arch.h"
+
+#if defined(LUAJIT_DISABLE_STDIO_FILE)
+
+#include <signal.h>
+#include <sys/syscall.h>
+
+// Calls to these functions should never be made. Abort if they are so
+// we can figure out why they're getting called.
+// 
+// As far as I can tell, the only references to these functions are via
+// lj_ircall.h. Since the reference is part of one big macro that builds
+// an enum, there's no easy way to conditionally exclude the ones we don't
+// want, and so this is the solution.
+
+#define lj_stdio_string(_name) #_name
+
+#define lj_stdio_alias(_name) \
+  extern __typeof(lj_stdio_##_name) _name __attribute__((__alias__(lj_stdio_string(lj_stdio_##_name))))
+
+int lj_stdio_fputc(int c, void *stream)
+{
+  syscall2(SYS_kill, syscall0(SYS_getpid), SIGABRT);
+  return 0;
+}
+lj_stdio_alias(fputc);
+
+int lj_stdio_fflush(void *stream)
+{
+  syscall2(SYS_kill, syscall0(SYS_getpid), SIGABRT);
+  return 0;
+}
+lj_stdio_alias(fflush);
+
+long lj_stdio_fwrite(const void *ptr, size_t size, size_t nmemb, void *stream)
+{
+  syscall2(SYS_kill, syscall0(SYS_getpid), SIGABRT);
+  return 0;
+}
+lj_stdio_alias(fwrite);
+
+int lj_stdio_panic(lua_State *L, void *panic_ud)
+{
+  syscall2(SYS_kill, syscall0(SYS_getpid), SIGABRT);
+  return 0;
+}
+
+long lj_stdio_print(lua_State *L, const void *p, size_t sz, void *print_ud)
+{
+  syscall2(SYS_kill, syscall0(SYS_getpid), SIGABRT);
+  return -1;
+}
+
+#else
+
+int lj_stdio_panic(lua_State *L, void *panic_ud)
+{
+  const char *s = lua_tostring(L, -1);
+  fputs("PANIC: unprotected error in call to Lua API (", stderr);
+  fputs(s ? s : "?", stderr);
+  fputc(')', stderr); fputc('\n', stderr);
+  fflush(stderr);
+  return 0;
+}
+
+long lj_stdio_print(lua_State *L, const void *p, size_t sz, void *print_ud)
+{
+  return fwrite(p, 1, sz, stdout);
+}
+
+#endif

--- a/src/luajit.h
+++ b/src/luajit.h
@@ -76,4 +76,12 @@ LUA_API const char *luaJIT_profile_dumpstack(lua_State *L, const char *fmt,
 /* Enforce (dynamic) linker error for version mismatches. Call from main. */
 LUA_API void LUAJIT_VERSION_SYM(void);
 
+typedef int (*lua_Panic)(lua_State *L, void *panic_ud);
+
+typedef long (*lua_Print)(lua_State *L, const void *p, size_t sz, void *print_ud);
+
+LUA_API lua_State *luaJIT_newstate(lua_Alloc alloc_f, void *alloc_ud,
+				   lua_Panic panic_f, void *panic_ud,
+				   lua_Print print_f, void *print_ud);
+
 #endif


### PR DESCRIPTION
Add a compile-time option to disable stdio `FILE` usage. This adds new panic and print function pointers that can be specified with a new LuaJIT-specific API, `luaJIT_newstate` to be used instead of `lua_newstate`. If this compile-time option is enabled, `lua_newstate` should not be used, as it will end up calling `fwrite`/`fflush`/`fputc` stubs that raise `SIGABRT`. This option is added to support environments that do not have stdio `FILE` support available.