### PR TITLE
Add compile-time option to disable errno exposure to Lua

### DIFF
--- a/src/lib_ffi.c
+++ b/src/lib_ffi.c
@@ -673,10 +673,14 @@ LJLIB_CF(ffi_offsetof)	LJLIB_REC(ffi_xof FF_ffi_offsetof)
 
 LJLIB_CF(ffi_errno)	LJLIB_REC(.)
 {
+#ifndef LUAJIT_DISABLE_ERRNO
   int err = errno;
   if (L->top > L->base)
     errno = ffi_checkint(L, 1);
   setintV(L->top++, err);
+#else
+  setintV(L->top++, 0);
+#endif
   return 1;
 }
 

--- a/src/lj_vmmath.c
+++ b/src/lj_vmmath.c
@@ -111,7 +111,11 @@ double lj_vm_foldfpm(double x, int fpm)
 #if LJ_HASFFI
 int lj_vm_errno(void)
 {
+#ifndef LUAJIT_DISABLE_ERRNO
   return errno;
+#else
+  return 0;
+#endif
 }
 #endif
 


### PR DESCRIPTION
Add a compile-time option to disable `errno` exposure to Lua. This makes sense when io and os modules are disabled, as well as clib ffi support. With this enabled, references to `errno` will simply return 0.