### PR TITLE
Stub out more code when LUAJIT_DISABLE_STDIO_FILE is defined

### DIFF
--- a/src/host/buildvm.c
+++ b/src/host/buildvm.c
@@ -283,7 +283,11 @@ IRFLDEF(FLNAME)
 
 const char *const ircall_names[] = {
 #define IRCALLNAME(cond, name, nargs, kind, type, flags)	#name,
-IRCALLDEF(IRCALLNAME)
+IRCALLDEF_0(IRCALLNAME)
+#ifndef LUAJIT_DISABLE_STDIO_FILE
+IRCALLDEF_STDIO(IRCALLNAME)
+#endif
+IRCALLDEF_1(IRCALLNAME)
 #undef IRCALLNAME
   NULL
 };

--- a/src/lib_debug.c
+++ b/src/lib_debug.c
@@ -361,6 +361,7 @@ LJLIB_CF(debug_gethook)
 
 LJLIB_CF(debug_debug)
 {
+#ifndef LUAJIT_DISABLE_STDIO_FILE
   for (;;) {
     char buffer[250];
     fputs("lua_debug> ", stderr);
@@ -375,6 +376,9 @@ LJLIB_CF(debug_debug)
     }
     lua_settop(L, 0);  /* remove eventual returns */
   }
+#else
+  return 0;
+#endif
 }
 
 /* ------------------------------------------------------------------------ */

--- a/src/lj_ir.c
+++ b/src/lj_ir.c
@@ -62,7 +62,11 @@ LJ_DATADEF const CCallInfo lj_ir_callinfo[] = {
 #define IRCALLCI(cond, name, nargs, kind, type, flags) \
   { (ASMFunction)IRCALLCOND_##cond(name), \
     (nargs)|(CCI_CALL_##kind)|(IRT_##type<<CCI_OTSHIFT)|(flags) },
-IRCALLDEF(IRCALLCI)
+IRCALLDEF_0(IRCALLCI)
+#ifndef LUAJIT_DISABLE_STDIO_FILE
+IRCALLDEF_STDIO(IRCALLCI)
+#endif
+IRCALLDEF_1(IRCALLCI)
 #undef IRCALLCI
   { NULL, 0 }
 };

--- a/src/lj_ircall.h
+++ b/src/lj_ircall.h
@@ -150,7 +150,7 @@ typedef struct CCallInfo {
 #endif
 
 /* Function definitions for CALL* instructions. */
-#define IRCALLDEF(_) \
+#define IRCALLDEF_0(_) \
   _(ANY,	lj_str_cmp,		2,  FN, INT, CCI_NOFPRCLOBBER) \
   _(ANY,	lj_str_find,		4,   N, PGC, 0) \
   _(ANY,	lj_str_new,		3,   S, STR, CCI_L|CCI_T) \
@@ -206,10 +206,12 @@ typedef struct CCallInfo {
   _(ANY,	atan,			1,   N, NUM, XA_FP) \
   _(ANY,	sinh,			1,   N, NUM, XA_FP) \
   _(ANY,	cosh,			1,   N, NUM, XA_FP) \
-  _(ANY,	tanh,			1,   N, NUM, XA_FP) \
+  _(ANY,	tanh,			1,   N, NUM, XA_FP)
+#define IRCALLDEF_STDIO(_) \
   _(ANY,	fputc,			2,   S, INT, 0) \
   _(ANY,	fwrite,			4,   S, INT, 0) \
-  _(ANY,	fflush,			1,   S, INT, 0) \
+  _(ANY,	fflush,			1,   S, INT, 0)
+#define IRCALLDEF_1(_) \
   /* ORDER FPM */ \
   _(FPMATH,	lj_vm_floor,		1,   N, NUM, XA_FP) \
   _(FPMATH,	lj_vm_ceil,		1,   N, NUM, XA_FP) \
@@ -270,7 +272,11 @@ typedef struct CCallInfo {
 
 typedef enum {
 #define IRCALLENUM(cond, name, nargs, kind, type, flags)	IRCALL_##name,
-IRCALLDEF(IRCALLENUM)
+IRCALLDEF_0(IRCALLENUM)
+#ifndef LUJIT_DISABLE_STDIO_FILE
+IRCALLDEF_STDIO(IRCALLENUM)
+#endif
+IRCALLDEF_1(IRCALLENUM)
 #undef IRCALLENUM
   IRCALL__MAX
 } IRCallID;


### PR DESCRIPTION
This adds to #6 to stub out more code when `LUAJIT_DISABLE_STDIO_FILE` is defined. I'm not certain why this code didn't get picked up in the initial changes, but here we are