### PR TITLE
Broaden open return value check for non-POSIX open implementation

### DIFF
--- a/src/lj_prng.c
+++ b/src/lj_prng.c
@@ -228,7 +228,7 @@ int LJ_FASTCALL lj_prng_seed_secure(PRNGState *rs)
   */
   {
     int fd = open("/dev/urandom", O_RDONLY|O_CLOEXEC);
-    if (fd != -1) {
+    if (fd >= 0) {
       ssize_t n = read(fd, rs->u, sizeof(rs->u));
       (void)close(fd);
       if (n == (ssize_t)sizeof(rs->u))


### PR DESCRIPTION
This broadens the return value check from `open`. POSIX says that `open` returns -1 on error and sets `errno`. But really, any value <= -1 should be considered an error. If, say, a host implementation of `open` is just a direct mapping to `SYS_openat` then there will be no `errno` set (which isn't checked here anyway) and the `errno` value will be encoded as `-errno`.