### PR TITLE
Prevent dead code compilation if LUAJIT_DISABLE_VMEVENT is defined

### DIFF
--- a/src/lj_vmevent.c
+++ b/src/lj_vmevent.c
@@ -16,6 +16,8 @@
 #include "lj_vm.h"
 #include "lj_vmevent.h"
 
+#ifndef LUAJIT_DISABLE_VMEVENT
+
 ptrdiff_t lj_vmevent_prepare(lua_State *L, VMEvent ev)
 {
   global_State *g = G(L);
@@ -56,3 +58,4 @@ void lj_vmevent_call(lua_State *L, ptrdiff_t argbase)
     g->vmevmask = oldmask;  /* Restore event mask, but not if not modified. */
 }
 
+#endif


### PR DESCRIPTION
Prevent dead code compilation if `LUAJIT_DISABLE_VMEVENT` is defined. These two functions are only called from macros that get stubbed out if `LUAJIT_DISABLE_VMEVENT` is defined. But in an environment with stripped down libc headers, compilation of this code can be problematic, so just stub it out altogether