### PR TITLE
Remove unnecessary stdio stubs

### DIFF
--- a/src/lj_stdio.c
+++ b/src/lj_stdio.c
@@ -15,40 +15,6 @@
 #include <signal.h>
 #include <sys/syscall.h>
 
-// Calls to these functions should never be made. Abort if they are so
-// we can figure out why they're getting called.
-// 
-// As far as I can tell, the only references to these functions are via
-// lj_ircall.h. Since the reference is part of one big macro that builds
-// an enum, there's no easy way to conditionally exclude the ones we don't
-// want, and so this is the solution.
-
-#define lj_stdio_string(_name) #_name
-
-#define lj_stdio_alias(_name) \
-  extern __typeof(lj_stdio_##_name) _name __attribute__((__alias__(lj_stdio_string(lj_stdio_##_name))))
-
-int lj_stdio_fputc(int c, void *stream)
-{
-  syscall2(SYS_kill, syscall0(SYS_getpid), SIGABRT);
-  return 0;
-}
-lj_stdio_alias(fputc);
-
-int lj_stdio_fflush(void *stream)
-{
-  syscall2(SYS_kill, syscall0(SYS_getpid), SIGABRT);
-  return 0;
-}
-lj_stdio_alias(fflush);
-
-long lj_stdio_fwrite(const void *ptr, size_t size, size_t nmemb, void *stream)
-{
-  syscall2(SYS_kill, syscall0(SYS_getpid), SIGABRT);
-  return 0;
-}
-lj_stdio_alias(fwrite);
-
 int lj_stdio_panic(lua_State *L, void *panic_ud)
 {
   syscall2(SYS_kill, syscall0(SYS_getpid), SIGABRT);


### PR DESCRIPTION
These stubs were needed early on to find locations using them, but they're no longer needed and causing more problems than they're worth.